### PR TITLE
Fixed a bug that lead to an infinite loop, and another involving weird my.cnf files.

### DIFF
--- a/src/nova/Log.cc
+++ b/src/nova/Log.cc
@@ -28,6 +28,8 @@ namespace {
                 return "ERROR";
             case Log::LEVEL_INFO:
                 return "INFO ";
+            case Log::LEVEL_TRACE:
+                return "TRACE";
             default:
                 return "UNKNOWN!";
         }
@@ -79,12 +81,12 @@ LogFileOptions::LogFileOptions(string path, optional<size_t> max_size,
  *---------------------------------------------------------------------------*/
 
 LogOptions::LogOptions(boost::optional<LogFileOptions> file,
-                       bool use_std_streams)
- : file(file), use_std_streams(use_std_streams) {
+                       bool use_std_streams, bool show_trace)
+ : file(file), show_trace(show_trace), use_std_streams(use_std_streams) {
 }
 
 LogOptions LogOptions::simple() {
-    LogOptions log_options(boost::none, true);
+    LogOptions log_options(boost::none, true, true);
     return log_options;
 }
 
@@ -233,6 +235,9 @@ bool Log::should_rotate_logs() {
 void Log::write(const char * file_name, int line_number, Log::Level level,
                 const char * message)
 {
+    if (level == LEVEL_TRACE && !options.show_trace) {
+        return;
+    }
     IsoDateTime time;
     const char * level_string = level_to_string(level);
     boost::lock_guard<boost::mutex> lock(mutex);

--- a/src/nova/Log.h
+++ b/src/nova/Log.h
@@ -47,8 +47,11 @@ namespace nova {
 
     struct LogOptions {
         boost::optional<LogFileOptions> file;
+        bool show_trace;
         bool use_std_streams;
-        LogOptions(boost::optional<LogFileOptions> file, bool use_std_streams);
+
+        LogOptions(boost::optional<LogFileOptions> file, bool use_std_streams,
+                   bool show_trace);
 
         /** Creates a simple set of LogOptions. Useful for tests. */
         static LogOptions simple();
@@ -80,7 +83,8 @@ namespace nova {
             enum Level {
                 LEVEL_DEBUG,
                 LEVEL_ERROR,
-                LEVEL_INFO
+                LEVEL_INFO,
+                LEVEL_TRACE
             };
 
             boost::optional<size_t> current_log_file_size();
@@ -170,6 +174,8 @@ namespace nova {
         __FILE__, __LINE__, nova::Log::LEVEL_INFO, arg); }
     #define NOVA_LOG_ERROR(arg) { nova::Log::get_instance()->write( \
         __FILE__, __LINE__, nova::Log::LEVEL_ERROR, arg); }
+    #define NOVA_LOG_TRACE(arg) { nova::Log::get_instance()->write( \
+        __FILE__, __LINE__, nova::Log::LEVEL_TRACE, arg); }
 
     #define NOVA_LOG_DEBUG2 nova::Log::get_instance()->write_fmt( \
         __FILE__, __LINE__, nova::Log::LEVEL_DEBUG)
@@ -177,6 +183,8 @@ namespace nova {
         __FILE__, __LINE__, nova::Log::LEVEL_INFO)
     #define NOVA_LOG_ERROR2 nova::Log::get_instance()->write_fmt( \
         __FILE__, __LINE__, nova::Log::LEVEL_ERROR)
+    #define NOVA_LOG_TRACE2 nova::Log::get_instance()->write_fmt( \
+        __FILE__, __LINE__, nova::Log::LEVEL_TRACE)
 }
 
 #endif

--- a/src/nova/db/mysql.cc
+++ b/src/nova/db/mysql.cc
@@ -34,6 +34,7 @@ namespace {
             const char* begin_of_new_string = line + start_index;
             const regoff_t match_size = end_index - start_index;
             if (match_size > 0) {
+                str.clear();
                 str.append(begin_of_new_string, match_size);
             }
         }

--- a/src/nova/flags.cc
+++ b/src/nova/flags.cc
@@ -293,6 +293,10 @@ optional<const char *> FlagValues::log_file_path() const {
     return get_flag_value<const char *>(*map, "log_file_path");
 }
 
+bool FlagValues::log_show_trace() const {
+    return get_flag_value<bool>(*map, "log_show_trace", false);
+}
+
 bool FlagValues::log_use_std_streams() const {
     return get_flag_value<bool>(*map, "log_use_std_streams", true);
 }

--- a/src/nova/flags.h
+++ b/src/nova/flags.h
@@ -113,6 +113,8 @@ class FlagValues {
 
         boost::optional<double> log_file_max_time() const;
 
+        bool log_show_trace() const;
+
         bool log_use_std_streams() const;
 
         /** Time MySQL we'll wait for the MySQL app to change from running to

--- a/src/nova/guest/mysql/MySqlAppStatus.cc
+++ b/src/nova/guest/mysql/MySqlAppStatus.cc
@@ -281,7 +281,7 @@ void MySqlAppStatus::update() {
     nova_db->ensure();
 
     if (is_mysql_installed() && !is_mysql_restarting()) {
-        NOVA_LOG_INFO("Determining status of MySQL app...");
+        NOVA_LOG_TRACE("Determining status of MySQL app...");
         Status status = get_actual_db_status();
         set_status(status);
     } else {

--- a/src/nova/guest/mysql/MySqlGuestException.cc
+++ b/src/nova/guest/mysql/MySqlGuestException.cc
@@ -22,6 +22,8 @@ MySqlGuestException::~MySqlGuestException() throw() {
 
 const char *  MySqlGuestException::code_to_string(Code code) {
     switch(code) {
+        case CANT_READ_ORIGINAL_MYCNF:
+            return "Can't read from original my.cnf file.";
         case CANT_WRITE_TMP_MYCNF:
             return "Couldn't write temp my.cnf file.";
         case COULD_NOT_START_MYSQL:

--- a/src/nova/guest/mysql/MySqlGuestException.h
+++ b/src/nova/guest/mysql/MySqlGuestException.h
@@ -11,6 +11,7 @@ namespace nova { namespace guest { namespace mysql {
 
         public:
             enum Code {
+                CANT_READ_ORIGINAL_MYCNF,
                 CANT_WRITE_TMP_MYCNF,
                 COULD_NOT_START_MYSQL,
                 COULD_NOT_STOP_MYSQL,

--- a/src/nova/process.cc
+++ b/src/nova/process.cc
@@ -20,10 +20,10 @@
 
 // Be careful with this Macro, as it comments out the entire line.
 #ifdef _NOVA_PROCESS_VERBOSE
-#define LOG_DEBUG(a) NOVA_LOG_DEBUG(a)
-#define LOG_DEBUG2(a, b) NOVA_LOG_DEBUG2(a, b)
-#define LOG_DEBUG3(a, b, c) NOVA_LOG_DEBUG2(a, b, c)
-#define LOG_DEBUG8(a, b, c, d, e, f, g, h) NOVA_LOG_DEBUG2(a, b, c, d, e, f, g, h)
+#define LOG_DEBUG(a) NOVA_LOG_TRACE(a)
+#define LOG_DEBUG2(a, b) NOVA_LOG_TRACE2(a, b)
+#define LOG_DEBUG3(a, b, c) NOVA_LOG_TRACE2(a, b, c)
+#define LOG_DEBUG8(a, b, c, d, e, f, g, h) NOVA_LOG_TRACE2(a, b, c, d, e, f, g, h)
 #else
 #define LOG_DEBUG(a) /* log.debug(a) */
 #define LOG_DEBUG2(a, b) /* log.debug(a, b) */
@@ -146,7 +146,7 @@ namespace {
                 str << " ";
             }
             str << "}";
-            LOG_DEBUG(str.str().c_str());
+            NOVA_LOG_DEBUG(str.str().c_str());
         }
         const posix_spawn_file_actions_t * file_actions = NULL;
         if (actions != 0) {
@@ -362,7 +362,7 @@ void Process::set_eof() {
         while(((child_pid = waitpid(pid, &status, options)) == -1)
               && (errno == EINTR));
         #ifdef _NOVA_PROCESS_VERBOSE
-            NOVA_LOG_DEBUG2("Child exited. child_pid=%d, pid=%d, Pid==pid=%s, "
+            NOVA_LOG_TRACE2("Child exited. child_pid=%d, pid=%d, Pid==pid=%s, "
                             "WIFEXITED=%d, WEXITSTATUS=%d, "
                             "WIFSIGNALED=%d, WIFSTOPPED=%d",
                             child_pid, pid,

--- a/src/receiver_daemon.cc
+++ b/src/receiver_daemon.cc
@@ -86,7 +86,7 @@ public:
         while(!quit) {
             unsigned long wait_time = next_periodic_task < next_reporting ?
                 next_periodic_task : next_reporting;
-            NOVA_LOG_DEBUG2("Waiting for %lu seconds...", wait_time);
+            NOVA_LOG_TRACE2("Waiting for %lu seconds...", wait_time);
             boost::posix_time::seconds time(wait_time);
             boost::this_thread::sleep(time);
             next_periodic_task -= wait_time;
@@ -105,7 +105,7 @@ public:
 
     void periodic_tasks() {
         START_THREAD_TASK();
-            NOVA_LOG_DEBUG2("Running periodic tasks...");
+            NOVA_LOG_TRACE2("Running periodic tasks...");
             status_updater->update();
             Log::rotate_logs_if_needed();
         END_THREAD_TASK("periodic_tasks()");
@@ -151,7 +151,8 @@ int main(int argc, char* argv[]) {
             log_file_options = boost::none;
         }
         LogOptions log_options(log_file_options,
-                               flags.log_use_std_streams());
+                               flags.log_use_std_streams(),
+                               flags.log_show_trace());
 
         LogApiScope log_api_scope(log_options);
 

--- a/tests/log_tests.cc
+++ b/tests/log_tests.cc
@@ -70,7 +70,7 @@ struct LogTestsFixture {
         }
         LogFileOptions file_options(log_file, boost::optional<size_t>(10000),
                     max_time_in_seconds, 3);
-        LogOptions options(optional<LogFileOptions>(file_options), false);
+        LogOptions options(optional<LogFileOptions>(file_options), false, false);
         nova::Log::initialize(options);
         ++ test_count;
     }


### PR DESCRIPTION
- Added a new Logging level, TRACE, for LOC I can't bear to part with but that no one really wants to see.
- Clear string when grabbing user name and password from my.cnf in case the file has both fields listed more than once.
- I had stupidly not checked the fail() property of the input file, leading to an infinite loop when the file was unreadable. Fixed.
