### PR TITLE
Cleaned up the program entry point.

### DIFF
--- a/src/nova/flags.cc
+++ b/src/nova/flags.cc
@@ -267,7 +267,7 @@ bool FlagValues::apt_use_sudo() const {
 }
 
 const char * FlagValues::control_exchange() const {
-    return map->get("control_exchange", "nova");
+    return map->get("control_exchange", "reddwarf");
 }
 
 const char * FlagValues::db_backend() const {

--- a/src/receiver_daemon.cc
+++ b/src/receiver_daemon.cc
@@ -5,6 +5,7 @@
 #include <boost/format.hpp>
 #include "nova/guest/guest.h"
 #include "nova/guest/diagnostics.h"
+#include <boost/foreach.hpp>
 #include "nova/guest/GuestException.h"
 #include "nova/guest/HeartBeat.h"
 #include <boost/lexical_cast.hpp>
@@ -19,6 +20,7 @@
 #include <sstream>
 #include <boost/thread.hpp>
 #include "nova/guest/utils.h"
+#include <vector>
 
 
 /* In release mode, all errors should be caught so the guest will not die.
@@ -50,7 +52,10 @@ using namespace nova::db::mysql;
 using namespace nova::guest::mysql;
 using namespace nova::rpc;
 using std::string;
+using std::vector;
 
+// Begin anonymous namespace.
+namespace {
 
 const char PERIODIC_MESSAGE [] =
     "{"
@@ -58,12 +63,17 @@ const char PERIODIC_MESSAGE [] =
     "    'args':{}"
     "}";
 
-static bool quit;
+/* Handles receiving and processing messages. */
+void message_loop(ResilentReceiver & receiver,
+                  vector<MessageHandlerPtr> & handlers);
 
-/* This runs in a different thread and just sends messages to the queue,
- * which cause the periodic_tasks to run. This keeps us from having to ensure
- * everything else is thread-safe. */
-//TODO(tim.simpson): Rename this to nova::service::Service.
+/* This is kind of a joke. There is no polite way to quit Sneaky. :p */
+static const bool quit = false;
+
+/**
+ * Sends updates back to Reddwarf regarding the status of both
+ * Sneaky Pete and the MySQL application.
+ */
 class PeriodicTasker {
 
 private:
@@ -126,15 +136,137 @@ AmqpConnectionPtr make_amqp_connection(FlagValues & flags) {
 
 }
 
+void initialize_and_run(FlagValues & flags) {
+    NOVA_LOG_INFO(" ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+    NOVA_LOG_INFO(" ^ ^ ^                                       ^");
+    NOVA_LOG_INFO(" ^ '  '       -----REDDWARF-GUEST-AGENT----- ^");
+    NOVA_LOG_INFO(" ^ \\`-'/        -------Sneaky--Pete-------   ^");
+    NOVA_LOG_INFO(" ^   |__                                     ^");
+    NOVA_LOG_INFO(" ^  /                         starting now...^");
+    NOVA_LOG_INFO(" ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+
+    // Initialize MySQL libraries. This should be done before spawning
+    // threads.
+    MySqlApiScope mysql_api_scope;
+
+    /* Create connection to Nova database. */
+    MySqlConnectionWithDefaultDbPtr nova_db(
+        new MySqlConnectionWithDefaultDb(
+            flags.nova_sql_host(), flags.nova_sql_user(),
+            flags.nova_sql_password(),
+            flags.nova_sql_database()));
+
+    /* Create JSON message handlers. */
+    vector<MessageHandlerPtr> handlers;
+
+    /* Create Apt Guest */
+    AptGuest apt_worker(flags.apt_use_sudo(),
+                        flags.apt_guest_config_package(),
+                        flags.apt_self_package_name(),
+                        flags.apt_self_update_time_out());
+    MessageHandlerPtr handler_apt(new AptMessageHandler(&apt_worker));
+    handlers.push_back(handler_apt);
+
+    /* Create MySQL updater. */
+    MySqlAppStatusPtr mysql_status_updater(new MySqlAppStatus(
+        nova_db,
+        flags.nova_db_reconnect_wait_time(),
+        flags.guest_id()));
+
+    /* Create MySQL Guest. */
+    MessageHandlerPtr handler_mysql(new MySqlMessageHandler());
+    handlers.push_back(handler_mysql);
+
+    MessageHandlerPtr handler_mysql_app(new MySqlAppMessageHandler(
+        apt_worker, mysql_status_updater,
+        flags.mysql_state_change_wait_time()));
+    handlers.push_back(handler_mysql_app);
+
+    /* Create the Interrogator for the guest. */
+    Interrogator interrogator;
+    MessageHandlerPtr handler_interrogator(
+        new InterrogatorMessageHandler(interrogator));
+    handlers.push_back(handler_interrogator);
+
+    /* Set host value. */
+    string actual_host = nova::guest::utils::get_host_name();
+    string host = flags.host().get_value_or(actual_host.c_str());
+
+    /* Create HeartBeat. */
+    HeartBeat heart_beat(nova_db, flags.guest_id());
+
+    /* Create tasker. */
+    PeriodicTasker tasker(heart_beat, mysql_status_updater);
+
+    /* Create AMQP connection. */
+    string topic = str(format("guestagent.%s") % flags.guest_id());
+
+    // This starts the thread.
+    boost::thread workerThread(&PeriodicTasker::loop, &tasker,
+                                   flags.periodic_interval(),
+                                   flags.report_interval());
+    // Before we go any further, lets all just chill out and take a nap.
+    // TODO(tim.simpson) For reasons I can only assume relate to an even
+    // worse bug I have been able to uncover, sleeping here keeps Sneaky
+    // Pete from morphing into Fat Pete (inexplicable 60 MB virtual memory
+    // increase).
+    boost::this_thread::sleep(boost::posix_time::seconds(3));
+
+    NOVA_LOG_INFO("Creating listener...");
+
+    ResilentReceiver receiver(flags.rabbit_host(), flags.rabbit_port(),
+                flags.rabbit_userid(), flags.rabbit_password(),
+                flags.rabbit_client_memory(), topic.c_str(),
+                flags.control_exchange(),  flags.rabbit_reconnect_wait_time());
+
+    message_loop(receiver, handlers);
+}
+
+void message_loop(ResilentReceiver & receiver,
+                  vector<MessageHandlerPtr> & handlers) {
+    while(!quit) {
+        GuestInput input = receiver.next_message();
+        NOVA_LOG_INFO2("method=%s", input.method_name.c_str());
+
+        GuestOutput output;
+
+        #ifdef CATCH_RPC_METHOD_ERRORS
+        try {
+        #endif
+            BOOST_FOREACH(MessageHandlerPtr & handler, handlers) {
+                output.result = handler->handle_message(input);
+                if (output.result) {
+                    break;
+                }
+            }
+            if (!output.result) {
+                NOVA_LOG_ERROR("No method found!")
+                throw GuestException(GuestException::NO_SUCH_METHOD);
+            }
+            output.failure = boost::none;
+        #ifdef CATCH_RPC_METHOD_ERRORS
+        } catch(const std::exception & e) {
+            NOVA_LOG_ERROR2("Error running method %s : %s",
+                       input.method_name.c_str(), e.what());
+            NOVA_LOG_ERROR(e.what());
+            output.result.reset();
+            output.failure = e.what();
+        }
+        #endif
+
+        receiver.finish_message(output);
+    }
+}
+
+} // End of anonymous namespace.
+
+/**
+ * Initializes the flag config and log options before passing
+ * the former to main_loop with all errors printed to STDERR in release mode.
+ */
 int main(int argc, char* argv[]) {
-    quit = false;
-
-    bool logging_initialized = false;
-
 #ifndef _DEBUG
-
     try {
-
 #endif
         /* Grab flag values. */
         FlagValues flags(FlagMap::create_from_args(argc, argv, true));
@@ -156,125 +288,19 @@ int main(int argc, char* argv[]) {
 
         LogApiScope log_api_scope(log_options);
 
-        logging_initialized = true;
-
-        NOVA_LOG_INFO(" ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
-        NOVA_LOG_INFO(" ^ ^ ^                                       ^");
-        NOVA_LOG_INFO(" ^ '  '       -----REDDWARF-GUEST-AGENT----- ^");
-        NOVA_LOG_INFO(" ^ \\`-'/        -------Sneaky--Pete-------   ^");
-        NOVA_LOG_INFO(" ^   |__                                     ^");
-        NOVA_LOG_INFO(" ^  /                         starting now...^");
-        NOVA_LOG_INFO(" ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
-
-        // Initialize MySQL libraries. This should be done before spawning
-        // threads.
-        MySqlApiScope mysql_api_scope;
-
-        /* Create connection to Nova database. */
-        MySqlConnectionWithDefaultDbPtr nova_db(
-            new MySqlConnectionWithDefaultDb(
-                flags.nova_sql_host(), flags.nova_sql_user(),
-                flags.nova_sql_password(),
-                flags.nova_sql_database()));
-
-        /* Create JSON message handlers. */
-        const int handler_count = 4;
-        MessageHandlerPtr handlers[handler_count];
-
-        /* Create Apt Guest */
-        AptGuest apt_worker(flags.apt_use_sudo(),
-                            flags.apt_guest_config_package(),
-                            flags.apt_self_package_name(),
-                            flags.apt_self_update_time_out());
-        handlers[0].reset(new AptMessageHandler(&apt_worker));
-
-        /* Create MySQL updater. */
-        MySqlAppStatusPtr mysql_status_updater(new MySqlAppStatus(
-            nova_db,
-            flags.nova_db_reconnect_wait_time(),
-            flags.guest_id()));
-
-        /* Create MySQL Guest. */
-        handlers[1].reset(new MySqlMessageHandler());
-
-        handlers[2].reset(new MySqlAppMessageHandler(
-            apt_worker, mysql_status_updater,
-            flags.mysql_state_change_wait_time()));
-
-        /* Create the Interrogator for the guest. */
-        Interrogator interrogator;
-        handlers[3].reset(new InterrogatorMessageHandler(interrogator));
-
-        /* Set host value. */
-        string actual_host = nova::guest::utils::get_host_name();
-        string host = flags.host().get_value_or(actual_host.c_str());
-
-        /* Create HeartBeat. */
-        HeartBeat heart_beat(nova_db, flags.guest_id());
-
-        /* Create tasker. */
-        PeriodicTasker tasker(heart_beat, mysql_status_updater);
-
-        /* Create AMQP connection. */
-        string topic = str(format("guestagent.%s") % flags.guest_id());
-
-        quit = false;
-
-        // This starts the thread.
-        boost::thread workerThread(&PeriodicTasker::loop, &tasker,
-                                       flags.periodic_interval(),
-                                       flags.report_interval());
-        // Before we go any further, lets all just chill out and take a nap.
-        // TODO(tim.simpson) For reasons I can only assume relate to an even
-        // worse bug I have been able to uncover, sleeping here keeps Sneaky
-        // Pete from morphing into Fat Pete (inexplicable 60 MB virtual memory
-        // increase).
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
-
-        NOVA_LOG_INFO("Creating listener...");
-
-        ResilentReceiver receiver(flags.rabbit_host(), flags.rabbit_port(), //<-- here?!
-                    flags.rabbit_userid(), flags.rabbit_password(),
-                    flags.rabbit_client_memory(), topic.c_str(),
-                    flags.control_exchange(),  flags.rabbit_reconnect_wait_time());
-
-        while(!quit) {
-            GuestInput input = receiver.next_message();
-            NOVA_LOG_INFO2("method=%s", input.method_name.c_str());
-
-            GuestOutput output;
-
-            #ifdef CATCH_RPC_METHOD_ERRORS
+        #ifndef _DEBUG
             try {
-            #endif
-                for (int i = 0; i < handler_count && !output.result; i ++) {
-                    output.result = handlers[i]->handle_message(input);
-                }
-                if (!output.result) {
-                    NOVA_LOG_ERROR("No method found!")
-                    throw GuestException(GuestException::NO_SUCH_METHOD);
-                }
-                output.failure = boost::none;
-            #ifdef CATCH_RPC_METHOD_ERRORS
-            } catch(const std::exception & e) {
-                NOVA_LOG_ERROR2("Error running method %s : %s",
-                           input.method_name.c_str(), e.what());
-                NOVA_LOG_ERROR(e.what());
-                output.result.reset();
-                output.failure = e.what();
+        #endif
+            initialize_and_run(flags);
+        #ifndef _DEBUG
+            } catch (const std::exception & e) {
+                NOVA_LOG_ERROR2("Error: %s", e.what());
             }
-            #endif
-
-            receiver.finish_message(output);
-        }
+        #endif
 
 #ifndef _DEBUG
     } catch (const std::exception & e) {
-        if (logging_initialized) {
-            NOVA_LOG_ERROR2("Error: %s", e.what());
-        } else {
-            std::cerr << "Error: " << e.what() << std::endl;
-        }
+        std::cerr << "Error: " << e.what() << std::endl;
     }
 #endif
     return 0;


### PR DESCRIPTION
- Split the entry point into a few pieces to make it easier to parse.
- A bug in release mode caused the logging system to shutdown before any error messages were printed, meaning whenever an initialization error happened all anyone saw was that the logging system wasn't initialized... oops. Fixed.
- Changed default value of control_exchange to "reddwarf."
